### PR TITLE
Update nuget packages

### DIFF
--- a/ShareFileSnapIn/GetSfClient.cs
+++ b/ShareFileSnapIn/GetSfClient.cs
@@ -1,24 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
+﻿using ShareFile.Api.Client.Exceptions;
 using System.Management.Automation;
-using ShareFile.Api;
-using ShareFile.Api.Models;
-using System.IO;
-using ShareFile.Api.Client.Requests;
-using System.Windows.Forms;
-using ShareFile.Api.Powershell.Browser;
-using System.Net;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using System.Security;
-using System.Runtime.InteropServices;
-using System.Resources;
-using Microsoft.Win32;
-using ShareFile.Api.Client.Exceptions;
 
 namespace ShareFile.Api.Powershell
 {

--- a/ShareFileSnapIn/NewSfClient.cs
+++ b/ShareFileSnapIn/NewSfClient.cs
@@ -1,15 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using ShareFile.Api.Powershell.Properties;
 using System.Management.Automation;
-using ShareFile.Api;
-using ShareFile.Api.Models;
-using System.IO;
-using ShareFile.Api.Client.Requests;
-using ShareFile.Api.Powershell.Properties;
-using ShareFile.Api.Powershell.Browser;
 
 namespace ShareFile.Api.Powershell
 {

--- a/ShareFileSnapIn/PSShareFileClient.cs
+++ b/ShareFileSnapIn/PSShareFileClient.cs
@@ -2,20 +2,17 @@
 using Newtonsoft.Json.Linq;
 using ShareFile.Api.Client;
 using ShareFile.Api.Client.Events;
-using ShareFile.Api.Models;
+using ShareFile.Api.Client.Models;
 using ShareFile.Api.Powershell.Browser;
 using ShareFile.Api.Powershell.Properties;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Security;
-using System.Text;
 using System.Threading;
-using System.Threading.Tasks;
 
 namespace ShareFile.Api.Powershell
 {

--- a/ShareFileSnapIn/Parallel/DownloadAction.cs
+++ b/ShareFileSnapIn/Parallel/DownloadAction.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Management.Automation;
-using System.Security.Cryptography;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using ShareFile.Api.Client.Transfers.Downloaders;
+﻿using System.IO;
 
 namespace ShareFile.Api.Powershell.Parallel
 {
@@ -16,7 +7,7 @@ namespace ShareFile.Api.Powershell.Parallel
     /// </summary>
     class DownloadAction : IAction
     {
-        private Models.File child;
+        private Client.Models.File child;
         private Client.ShareFileClient client;
         private int downloadId;
         private FileSystemInfo target;
@@ -42,7 +33,7 @@ namespace ShareFile.Api.Powershell.Parallel
             }
         }
 
-        public DownloadAction(FileSupport fileSupport, Client.ShareFileClient client, int downloadId, Models.File child, FileSystemInfo target, ActionType type)
+        public DownloadAction(FileSupport fileSupport, Client.ShareFileClient client, int downloadId, Client.Models.File child, FileSystemInfo target, ActionType type)
         {
             this.child = child;
             this.client = client;
@@ -70,7 +61,7 @@ namespace ShareFile.Api.Powershell.Parallel
 
                     progressInfo.ProgressTotal(progressInfo.FileIndex, child.FileSizeBytes.GetValueOrDefault());
 
-                    downloader.OnTransferProgress =
+                    downloader.OnTransferProgress +=
                         (sender, args) =>
                         {
                             if (args.Progress.TotalBytes > 0)

--- a/ShareFileSnapIn/Parallel/Utility.cs
+++ b/ShareFileSnapIn/Parallel/Utility.cs
@@ -1,12 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using ShareFile.Api.Client.Models;
+using System;
 using System.IO;
-using System.Linq;
 using System.Management.Automation;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
-using ShareFile.Api.Models;
 
 namespace ShareFile.Api.Powershell.Parallel
 {

--- a/ShareFileSnapIn/SendSfRequest.cs
+++ b/ShareFileSnapIn/SendSfRequest.cs
@@ -1,17 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Management.Automation;
-using ShareFile.Api;
-using ShareFile.Api.Models;
-using System.IO;
+﻿using ShareFile.Api.Client.Exceptions;
+using ShareFile.Api.Client.Models;
 using ShareFile.Api.Client.Requests;
-using Newtonsoft.Json;
-using ShareFile.Api.Client.Exceptions;
-using System.Collections;
 using ShareFile.Api.Client.Requests.Filters;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
 using System.Text.RegularExpressions;
 
 namespace ShareFile.Api.Powershell
@@ -150,9 +144,9 @@ namespace ShareFile.Api.Powershell
             {
                 WriteError(new ErrorRecord(new Exception(e.Code.ToString() + ": " + e.ODataExceptionMessage.Message), e.Code.ToString(), ErrorCategory.NotSpecified, query.GetEntity()));
             }
-            catch(Exception e)
+            catch (Exception)
             {
-                ShowSuggestion(Entity,Action,Parameters);
+                ShowSuggestion(Entity, Action, Parameters);
                 throw;
             }
         }

--- a/ShareFileSnapIn/ShareFileDriveInfo.cs
+++ b/ShareFileSnapIn/ShareFileDriveInfo.cs
@@ -1,4 +1,5 @@
 ﻿using ShareFile.Api.Client;
+using ShareFile.Api.Client.Models;
 using System;
 using System.Management.Automation;
 
@@ -10,7 +11,7 @@ namespace ShareFile.Api.Powershell
 
         public Uri RootUri { get; set; }
 
-        public Models.Item RootItem { get; set; }
+        public Item RootItem { get; set; }
 
         public ShareFileDriveInfo(PSDriveInfo driveInfo, ShareFileDriveParameters driveParams)
             : base( driveInfo )

--- a/ShareFileSnapIn/ShareFileSnapIn.csproj
+++ b/ShareFileSnapIn/ShareFileSnapIn.csproj
@@ -52,18 +52,20 @@
     <Reference Include="Microsoft.Web.WebView2.Wpf, Version=1.0.2849.39, Culture=neutral, PublicKeyToken=2a8ab48044d2601e, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.WebView2.1.0.2849.39\lib\net462\Microsoft.Web.WebView2.Wpf.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.3.1.0.0\lib\net45\NLog.dll</HintPath>
+    <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
+      <HintPath>..\packages\NLog.5.3.4\lib\net46\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="ShareFile.Api.Client, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\ShareFile.Api.Client.3.4.140\lib\net45\ShareFile.Api.Client.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="ShareFile.Api.Client, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\ShareFile.Api.Client.4.0.200\lib\net462\ShareFile.Api.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Configuration.Install" />
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />

--- a/ShareFileSnapIn/app.config
+++ b/ShareFileSnapIn/app.config
@@ -1,14 +1,22 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.20.0" newVersion="4.2.20.0"/>
+        <assemblyIdentity name="System.Net.Http.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.20.0" newVersion="4.2.20.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
   </startup>
 </configuration>

--- a/ShareFileSnapIn/packages.config
+++ b/ShareFileSnapIn/packages.config
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Web.WebView2" version="1.0.2849.39" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net451" />
-  <package id="NLog" version="3.1.0.0" targetFramework="net451" />
-  <package id="ShareFile.Api.Client" version="3.4.140" targetFramework="net451" />
-  <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="NLog" version="5.3.4" targetFramework="net48" />
+  <package id="ShareFile.Api.Client" version="4.0.200" targetFramework="net48" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net48" />
+  <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net48" />
 </packages>

--- a/Test-ShareFileSnapIn/Test-ShareFileSnapIn.csproj
+++ b/Test-ShareFileSnapIn/Test-ShareFileSnapIn.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Utils.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="NLog.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/Test-ShareFileSnapIn/app.config
+++ b/Test-ShareFileSnapIn/app.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
Updated `Newtonsoft.Json`, `NLog`, and `ShareFile.Api.Client` packages.

Some minor changes had to be made after updating the `ShareFile.Api.Client` package.
Verified uploads/downloads still work as expected.

The `Newtonsoft.Json` package also includes a security fix.